### PR TITLE
Add Python 3.7, nightly, and flake8 to testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,26 @@
 language: python
 
-os:
-    - linux
-
 python:
     - 2.7
     - 3.5
     - 3.6
 
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial  # required for Python >= 3.7
+    - python: nightly
+      dist: xenial  # required for Python >= 3.7
+  allow_failures:
+    - python: nightly
+
 install:
   - pip install -r requirements.txt
   - pip install -r test-requirements.txt
-  - pip install codecov
+  - pip install codecov flake8
 
 script:
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
   - pytest --cov=autodeploy --cov-report term-missing
 
 after_success:


### PR DESCRIPTION
On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__python/black__](https://github.com/python/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.